### PR TITLE
add eval functions

### DIFF
--- a/src/dg_commons/evals/evaluate_comfort.py
+++ b/src/dg_commons/evals/evaluate_comfort.py
@@ -1,0 +1,57 @@
+import numpy as np
+from dg_commons import U, DgSampledSequence
+
+
+def get_max_jerk(commands: DgSampledSequence[U]):
+    length = len(commands.timestamps)
+    last_command = commands.values[0]
+    last_t = commands.timestamps[0]
+    max_jerk = 0
+    for idx in range(1, length):
+        cur_command = commands.values[idx]
+        cur_t = commands.timestamps[idx]
+        jerk = (cur_command.acc - last_command.acc) / float(cur_t - last_t)
+        if np.abs(jerk) > max_jerk:
+            max_jerk = np.abs(jerk)
+        last_command = cur_command
+        last_t = cur_t
+    return max_jerk
+
+
+def get_acc_rms(commands: DgSampledSequence[U]):
+    """
+    comfort measurement according to ISO 2631
+    the rms of frequency weighted acceletation
+    the
+    :param states:
+    :return:
+    """
+    acc_time = []
+    for idx in range(len(commands.timestamps)):
+        acc_time.append(commands.values[idx].acc)
+    acc_time = np.array(acc_time)
+    n_acc = len(acc_time)
+    st = 0.1
+    acc_freq = np.fft.rfft(acc_time)
+    freq = np.fft.rfftfreq(n=n_acc, d=st)
+    acc_freq_weighted = []
+    for idx in range(len(freq)):
+        acc_freq_weighted.append(acc_freq[idx] * acc_freq_filter(freq[idx]))
+    acc_freq_weighted = np.array(acc_freq_weighted)
+    acc_time_weighted = np.fft.irfft(acc_freq_weighted)
+    acc_rms = 0
+    for acc in acc_time_weighted:
+        acc_rms += np.square(acc)
+    acc_rms = np.sqrt(acc_rms/len(acc_time_weighted))
+    return acc_rms
+
+
+def acc_freq_filter(freq: float) -> float:
+    """
+    reference:
+    Low order continuous-time filters for approximation of the ISO 2631-1 human vibration sensitivity weightings
+    :param freq:
+    :return: 3rd-order approximated weight for horizonal acceleration
+    """
+    w = (14.55 * freq ** 2 + 6.026 * freq + 7.725) / (freq ** 3 + 15.02 * freq ** 2 + 51.63 * freq + 47.61)
+    return w

--- a/src/dg_commons/evals/evaluate_efficiency.py
+++ b/src/dg_commons/evals/evaluate_efficiency.py
@@ -1,0 +1,123 @@
+from math import sqrt
+from typing import Optional
+
+import numpy as np
+from commonroad.scenario.lanelet import Lanelet, LaneletNetwork
+from dg_commons.geo import PoseState, SE2Transform
+from dg_commons import X, U, DgSampledSequence, iterate_with_dt
+from dg_commons.sim.goals import RefLaneGoal
+from dg_commons.maps.lanes import DgLanelet
+from dg_commons.seq.sequence import Timestamp
+
+
+def distance_traveled(states: DgSampledSequence[X]) -> float:
+    dist: float = 0
+    for it in iterate_with_dt(states):
+        dist += sqrt((it.v1.x - it.v0.x) ** 2 + (it.v1.y - it.v0.y) ** 2)
+    return dist
+
+
+def actuation_effort(commands: DgSampledSequence[U]) -> float:
+    pass
+
+
+def time_goal_lane_reached(lanelet_network: LaneletNetwork, goal_lane: RefLaneGoal, states: DgSampledSequence[X],
+                           pos_tol: float = 0.8,
+                           heading_tol: float = 0.08) -> Timestamp:
+    reached_time = -1.0
+    # for idx in range(1, len(states.values) + 1):
+    #     state = states.values[-idx]
+    #     timestep = states.timestamps[-idx]
+    #     reached = desired_lane_reached(lanelet_network, goal_lane, state, pos_tol, heading_tol)
+    #     if not reached:
+    #         break
+    #     reached_time = timestep
+    for idx in range(0, len(states.values)):
+        state = states.values[idx]
+        timestep = states.timestamps[idx]
+        reached = desired_lane_reached(lanelet_network, goal_lane, state, pos_tol, heading_tol)
+        if reached:
+            reached_time = timestep
+            break
+    return float(reached_time)
+
+
+def desired_lane_reached(lanelet_network: LaneletNetwork, goal_lane: RefLaneGoal, state: X, pos_tol: float,
+                         heading_tol: float) -> bool:
+    """
+
+    :param state: the last ego state in the simulation
+    :param goal_lane: the desired lane
+    :return: True if the ego vehicle has reached the goal lane or any of its successors. Reached means the vehicle
+    center is close to the lane center and the heading is aligned with the lane.
+    """
+    ego_posestate = PoseState(x=state.x, y=state.y, psi=state.psi)
+    ego_pose = SE2Transform.from_PoseState(ego_posestate)
+    ref_lane = goal_lane.ref_lane  # dglanelet
+    lane_pose = ref_lane.lane_pose_from_SE2Transform(ego_pose)
+    while not lane_pose.along_inside:
+        if np.abs(lane_pose.along_lane) < 1.0 or lane_pose.along_lane - ref_lane.get_lane_length() < 1.0:
+            # not inside the lane but close enough
+            break
+        if lane_pose.along_after:
+            ref_lane = get_successor_dglane(lanelet_network, ref_lane)
+            if ref_lane is not None:
+                lane_pose = ref_lane.lane_pose_from_SE2Transform(ego_pose)
+            else:
+                break
+        if lane_pose.along_before:
+            ref_lane = get_predecessor_dglane(lanelet_network, ref_lane)
+            if ref_lane is not None:
+                lane_pose = ref_lane.lane_pose_from_SE2Transform(ego_pose)
+            else:
+                break
+
+    if goal_lane.is_fulfilled(state):
+        return True
+    # vehicle still on the road and is inside the desired lane, check its pose
+    if lane_pose.lateral_inside and lane_pose.distance_from_center < pos_tol and abs(
+            lane_pose.relative_heading) < heading_tol:
+        return True
+    else:
+        return False
+
+
+def get_lanelet_from_dglanelet(lanelet_network: LaneletNetwork, dglanelet: DgLanelet) -> Lanelet:
+    ref_point = dglanelet.control_points[1].q.p
+    lane_id = lanelet_network.find_lanelet_by_position([ref_point])[0][0]
+    lanelet = lanelet_network.find_lanelet_by_id(lane_id)
+    return lanelet
+
+
+def get_successor_lane(lanelet_network: LaneletNetwork, cur_lane: Lanelet | DgLanelet) -> Optional[Lanelet]:
+    if isinstance(cur_lane, DgLanelet):
+        cur_lane = get_lanelet_from_dglanelet(lanelet_network, cur_lane)
+    if len(cur_lane.successor) > 0:
+        return lanelet_network.find_lanelet_by_id(cur_lane.successor[0])
+    else:
+        return None
+
+
+def get_successor_dglane(lanelet_network: LaneletNetwork, cur_lane: Lanelet | DgLanelet) -> Optional[DgLanelet]:
+    suc_lanelet = get_successor_lane(lanelet_network, cur_lane)
+    if suc_lanelet is None:
+        return None
+    else:
+        return DgLanelet.from_commonroad_lanelet(suc_lanelet)
+
+
+def get_predecessor_lane(lanelet_network: LaneletNetwork, cur_lane: Lanelet | DgLanelet) -> Optional[Lanelet]:
+    if isinstance(cur_lane, DgLanelet):
+        cur_lane = get_lanelet_from_dglanelet(lanelet_network, cur_lane)
+    if len(cur_lane.predecessor) > 0:
+        return lanelet_network.find_lanelet_by_id(cur_lane.predecessor[0])
+    else:
+        return None
+
+
+def get_predecessor_dglane(lanelet_network: LaneletNetwork, cur_lane: Lanelet | DgLanelet) -> Optional[DgLanelet]:
+    pre_lanelet = get_predecessor_lane(lanelet_network, cur_lane)
+    if pre_lanelet is None:
+        return None
+    else:
+        return DgLanelet.from_commonroad_lanelet(pre_lanelet)

--- a/src/dg_commons/evals/evaluate_safety.py
+++ b/src/dg_commons/evals/evaluate_safety.py
@@ -1,0 +1,228 @@
+from typing import Mapping, MutableMapping
+import numpy as np
+from shapely import distance
+from shapely.ops import nearest_points
+from shapely.geometry import Polygon
+from shapely.affinity import translate
+from geometry import SE2_from_xytheta
+from dg_commons import apply_SE2_to_shapely_geo
+from dg_commons import PlayerName, X
+from dg_commons.sim import CollisionReport
+from dg_commons.sim.goals import TPlanningGoal
+from dg_commons.sim.simulator import LogEntry
+from dg_commons.sim.simulator_structures import SimLog, SimModel
+from dg_commons.seq.sequence import Timestamp
+
+
+def has_collision(cr_list: list[CollisionReport]) -> bool:
+    """Check whether the ego vehicle is involved in a collision."""
+    ego_name = PlayerName("Ego")
+    collided_players: set[PlayerName] = set()
+    for cr in cr_list:
+        collided_players.update((cr.players.keys()))
+    has_collided = True if ego_name in collided_players else False
+    return has_collided
+
+
+def get_min_dist(logs: SimLog, models: MutableMapping[PlayerName, SimModel],
+                 missions: Mapping[PlayerName, TPlanningGoal], ego_name: PlayerName) -> (
+        float, PlayerName, Timestamp):
+    """Get the minimum distance between the ego and any other agent throughout the simulation."""
+    timesteps = logs[ego_name].states.timestamps
+    min_dist = np.inf
+    min_dist_agent = None
+    min_dist_t = None
+    for t in timesteps:
+        min_dist_at_t, min_dist_agent_at_t = get_min_dist_at_t(logs, models, missions, t, ego_name)
+        if min_dist_at_t < min_dist:
+            min_dist = min_dist_at_t
+            min_dist_agent = min_dist_agent_at_t
+            min_dist_t = t
+    return min_dist, min_dist_agent, min_dist_t
+
+
+def get_min_ttc_max_drac(logs: SimLog, models: MutableMapping[PlayerName, SimModel],
+                         missions: Mapping[PlayerName, TPlanningGoal],
+                         ego_name: PlayerName) -> (
+        float, PlayerName, Timestamp):
+    """Get te minimum ttc and maximum drac throughout the simulation.
+    Returns the value, the agent involved and the time when the value is obtained."""
+    timesteps = logs[ego_name].states.timestamps
+    min_ttc = np.inf
+    min_ttc_agent = None
+    min_ttc_t = None
+    max_drac = -np.inf
+    max_drac_agent = None
+    max_drac_t = None
+    for t in timesteps:
+        ttc_at_t, ttc_agent_at_t, drac_at_t, drac_agent_at_t = get_ttc_drac_at_t(logs, models, missions, t, ego_name)
+        if ttc_at_t < min_ttc:
+            min_ttc = ttc_at_t
+            min_ttc_agent = ttc_agent_at_t
+            min_ttc_t = t
+        if drac_at_t > max_drac:
+            max_drac = drac_at_t
+            max_drac_agent = drac_agent_at_t
+            max_drac_t = t
+    return min_ttc, min_ttc_agent, min_ttc_t, max_drac, max_drac_agent, max_drac_t
+
+
+def get_min_dist_at_t(logs: SimLog, models: MutableMapping[PlayerName, SimModel],
+                      missions: Mapping[PlayerName, TPlanningGoal], t: Timestamp,
+                      ego_name: PlayerName) -> (float, PlayerName):
+    """
+    Compute the minimum distance between the ego vehicle and the agents at current timestep.
+    :param logs: simulation log
+    :param models: models of all agents
+    :param missions: missions of all agents
+    :param t: sim time
+    :param ego_name:
+    :return: min dist, the closest agent from ego
+    """
+    logs_at_t = logs.at_interp(t)
+    logs_at_t = _remove_finished_players(logs_at_t, missions)
+    if ego_name not in logs_at_t.keys():
+        # ego accomplished its goal
+        return np.inf, None
+    ego_state = logs_at_t[ego_name].state
+    ego_model = models[ego_name]
+    ego_pos = np.array([ego_state.x, ego_state.y])
+    min_dist = np.inf
+    min_dist_agent = None
+    for name, log in logs_at_t.items():
+        if name == ego_name:
+            continue
+        # agent_pos = np.array([log.state.x, log.state.y])
+        # dist = np.linalg.norm(agent_pos - ego_pos)
+        agent_state = log.state
+        agent_model = models[name]
+        dist, _ = _get_dist(ego_state, agent_state, ego_model, agent_model)
+        if dist < min_dist:
+            min_dist = dist
+            min_dist_agent = name
+    return min_dist, min_dist_agent
+
+
+def get_ttc_drac_at_t(logs: SimLog, models: MutableMapping[PlayerName, SimModel],
+                      missions: Mapping[PlayerName, TPlanningGoal], t: Timestamp, ego_name: PlayerName) -> (
+        float, PlayerName, float, PlayerName):
+    """
+    Compute the minimum time-to-collision and the maximum deceleration-rate-to-avoid-collision for the ego vehicle
+    against all agents at current timestep.
+    :param logs: simulation log
+    :param models: models of all agents
+    :param missions: missions of all agents
+    :param t: sim time
+    :param ego_name:
+    :return: ttc, the opponent agent involved in ttc, drac, the opponent agent involved in drac
+    """
+    # time to collision
+    logs_at_t = logs.at_interp(t)
+    logs_at_t = _remove_finished_players(logs_at_t, missions)
+    if ego_name not in logs_at_t.keys():
+        # ego accomplished its goal
+        return np.inf, None, -np.inf, None
+    ego_state = logs_at_t[ego_name].state
+    ego_model = models[ego_name]
+    ego_pos = np.array([ego_state.x, ego_state.y])
+    ego_vel = ego_state.vx * np.array([np.cos(ego_state.psi), np.sin(ego_state.psi)])
+    min_time = np.inf
+    min_ttc_agent = None
+    max_drac = -np.inf
+    max_drac_agent = None
+    for name, log in logs_at_t.items():
+        if name == ego_name:
+            continue
+        agent_state = log.state
+        agent_pos = np.array([agent_state.x, agent_state.y])
+        agent_model = models[name]
+        agent_vel = agent_state.vx * np.array([np.cos(agent_state.psi), np.sin(agent_state.psi)])
+        dist_center = np.linalg.norm(agent_pos - ego_pos)
+        rel_vel_along_dist = np.dot(agent_vel - ego_vel, (agent_pos - ego_pos) / dist_center)
+        if rel_vel_along_dist > 0 or np.abs(dist_center / rel_vel_along_dist) > 5.0:
+            # two agents are leaving each other or far enough
+            continue
+        ttc, ego_dtc, agent_dtc = _get_ttc(ego_state, agent_state, ego_model, agent_model)
+        drac = ego_state.vx ** 2 / (2 * ego_dtc)
+        if ttc < min_time:
+            min_time = ttc
+            min_ttc_agent = name
+        if drac > max_drac:
+            max_drac = drac
+            max_drac_agent = name
+
+    return min_time, min_ttc_agent, max_drac, max_drac_agent
+
+
+def _get_dist(state1: X, state2: X, model1: SimModel, model2: SimModel) -> (float, np.ndarray):
+    """get the minimum distance between two vehicles, considering their geometry"""
+    pose1 = SE2_from_xytheta([state1.x, state1.y, state1.psi])
+    poly1 = apply_SE2_to_shapely_geo(model1.vg.outline_as_polygon, pose1)
+    pose2 = SE2_from_xytheta([state2.x, state2.y, state2.psi])
+    poly2 = apply_SE2_to_shapely_geo(model2.vg.outline_as_polygon, pose2)
+    nearest_pts = nearest_points(poly1, poly2)
+    dist = distance(nearest_pts[0], nearest_pts[1])
+    pt1 = np.array([nearest_pts[0].x, nearest_pts[0].y])
+    pt2 = np.array([nearest_pts[1].x, nearest_pts[1].y])
+    dir = (pt2 - pt1) / np.linalg.norm(pt2 - pt1)
+    return dist, dir
+
+
+def _get_ttc(state1: X, state2: X, model1: SimModel, model2: SimModel) -> (float, float, float):
+    """
+    Compute the time-to-collision and distance-to-collisions of the two vehicles, considering their geometry.
+    :param poly1: geometry of the first agent
+    :param poly2: geometry of the second agent
+    :param state1: current state of the first agent
+    :param state2: current state of the second agent
+    :return: time-to-collision, distance-to-collision for agent1. distance-to-collision for agent2
+    """
+    pose1 = SE2_from_xytheta([state1.x, state1.y, state1.psi])
+    poly1 = apply_SE2_to_shapely_geo(model1.vg.outline_as_polygon, pose1)
+    pose2 = SE2_from_xytheta([state2.x, state2.y, state2.psi])
+    poly2 = apply_SE2_to_shapely_geo(model2.vg.outline_as_polygon, pose2)
+    ttc, dist_to_collision1, dist_to_collision2 = _get_ttc_of_poly_and_state(poly1, poly2, state1, state2)
+    return ttc, dist_to_collision1, dist_to_collision2
+
+
+def _get_ttc_of_poly_and_state(poly1: Polygon, poly2: Polygon, state1: X, state2: X):
+    """
+    Compute the time-to-collision and distance-to-collisions of the two polygons, considering their geometry.
+    :param poly1: geometry of the first agent
+    :param poly2: geometry of the second agent
+    :param state1: current state of the first agent
+    :param state2: current state of the second agent
+    :return: time-to-collision, distance-to-collision for agent1. distance-to-collision for agent2
+    """
+    time = 0
+    max_time = 3.0
+    timestep = 0.1
+    v1 = state1.vx * np.array([np.cos(state1.psi), np.sin(state1.psi)])
+    v2 = state2.vx * np.array([np.cos(state2.psi), np.sin(state2.psi)])
+    delta_pos = (v2 - v1) * timestep
+    while not poly1.intersects(poly2):
+        if time > max_time:
+            break
+        # move poly2
+        poly2 = translate(poly2, xoff=delta_pos[0], yoff=delta_pos[1])
+        time += timestep
+    # if time <= max_time:
+    return time, state1.vx * time, state2.vx * time
+    # return np.inf, np.inf, np.inf
+
+
+def _remove_finished_players(log_at_t: Mapping[PlayerName, LogEntry], missions: Mapping[PlayerName, TPlanningGoal]) -> \
+        Mapping[PlayerName, LogEntry]:
+    """
+    Remove the agents that have acomplished their goal.
+    :param log_at_t: collection of players and their log(state, command, etc.) at time t
+    :param missions: the goal of each player
+    :return: a now collection of running players and their logs.
+    """
+    log_new = {}
+    for name, log in log_at_t.items():
+        mission = missions[name]
+        state = log.state
+        if not mission.is_fulfilled(state):
+            log_new[name] = log
+    return log_new


### PR DESCRIPTION
Add common functions to evaluate the performance of ego vehicle in the simulation.
For safety, the functions to find the minimum distance, minimum time-to-collision(ttc) and maximum deceleration-rate-to-avoid-collision(drac) are implemented. The vehicle geometry is considered in the computation.
For efficiency, the function to find the first time that the ego vehicle entered its desired lane is implemented. It only checks whether the vehicle enters the goal lane(or its predecessor/successor), regardless of the progress on the lane.
For comfort, the max jerk and the rms of frequency-weighted acceleration(according to ISO2631) is computed.

This will be merged after tested locally for the pdm4ar exercise.