### PR TITLE
fix arm64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ exclude = ["src/dg_commons_tests/**"]
 [tool.poetry.dependencies]
 python = "^3.9"
 #dg-commonroad-drivability-checker = "2023.11"
-commonroad-drivability-checker = "2024.1"
+dg-commonroad-drivability-checker = "2024.1"
 frozendict = "^2.3.4"
 cytoolz = "^0.12.0"
 cachetools = "^5.0.0"


### PR DESCRIPTION
Fix building commonroad-drivability-checker on arm64. 
Cleaned from branch pdm4ar2024/fix-arm64.